### PR TITLE
Minor  documentation update for v1.5.0-RC

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -38,7 +38,7 @@ tox>=3.0.0, !=3.16.1
 ###
 # flake8 - MIT licence
 flake8>=3.9.2
-# pyflakes - ??? licence
+# pyflakes - MIT licence
 # pyflakes>=2.5.0
 # pep8 - ??? licence
 pep8>=1.0
@@ -58,5 +58,5 @@ coverage>=6.2
 wheel>=0.37.0
 # pip - builtin?? - PSF licence
 pip>=19.0
-# build - ?? licence
+# build - MIT licence
 # build>=0.5.1, !=1.0.3, !=0.6, !=0.6.1 !=1.1.0 !=1.2.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -30,7 +30,7 @@ setuptools>=38.0, !=71.0.1, !=72.0, !=69.4.0, !=69.3.0, !=60.3.0, !=59.1
 virtualenv>=15.0.1
 # pgpy - BSD 3-Clause licensed
 #pgpy>=0.4.1
-# tox - ??? licence
+# tox - MIT licence
 tox>=3.0.0, !=3.16.1
 #py>=1.4.33
 ###

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -36,7 +36,7 @@ tox>=3.0.0, !=3.16.1
 ###
 # TESTING ONLY - Do NOT report issues with these optionals on python-repo
 ###
-# flake8 - ??? licence
+# flake8 - MIT licence
 flake8>=3.9.2
 # pyflakes - ??? licence
 # pyflakes>=2.5.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated licensing information for several dependencies in the tests requirements, now explicitly stating the MIT license for `tox`, `flake8`, `pyflakes`, and `build`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->