### PR TITLE
[FEATURE] implemented reading and sending from stdin for SAY CMD

### DIFF
--- a/multicast/send.py
+++ b/multicast/send.py
@@ -337,8 +337,8 @@ class McastSAY(multicast.mtool):
 		Returns:
 			tuple: A tuple containing a status indicator and result message.
 		"""
-		group = kwargs.get("group", [multicast._MCAST_DEFAULT_GROUP])
-		port = kwargs.get("port", multicast._MCAST_DEFAULT_PORT)
+		group = kwargs.get("group", multicast._MCAST_DEFAULT_GROUP)  # skipcq: PYL-W0212 - module ok
+		port = kwargs.get("port", multicast._MCAST_DEFAULT_PORT)  # skipcq: PYL-W0212 - module ok
 		data = kwargs.get("data")
 		if data == ['-']:
 			# Read from stdin in chunks
@@ -352,5 +352,5 @@ class McastSAY(multicast.mtool):
 			message = str(""" """).join(data)
 			self._sayStep(group, port, message)
 		else:
-			message = str(data, encoding='utf8')
+			message = data.decode('utf8') if isinstance(data, bytes) else str(data)
 			self._sayStep(group, port, message)

--- a/multicast/send.py
+++ b/multicast/send.py
@@ -337,9 +337,20 @@ class McastSAY(multicast.mtool):
 		Returns:
 			tuple: A tuple containing a status indicator and result message.
 		"""
-		return self._sayStep(
-			kwargs.get("group", [multicast._MCAST_DEFAULT_GROUP]),  # skipcq: PYL-W0212 - module ok
-			kwargs.get("port", multicast._MCAST_DEFAULT_PORT),  # skipcq: PYL-W0212 - module ok
-			None if "data" not in kwargs else str(kwargs["data"]),
-		)
-
+		group = kwargs.get("group", [multicast._MCAST_DEFAULT_GROUP])
+		port = kwargs.get("port", multicast._MCAST_DEFAULT_PORT)
+		data = kwargs.get("data")
+		if data == ['-']:
+			# Read from stdin in chunks
+			while True:
+				chunk = sys.stdin.read(1316)  # Read 1316 bytes at a time - matches read size
+				if not chunk:
+					break
+				self._sayStep(group, port, chunk)
+		elif isinstance(data, list):
+			# Join multiple arguments into a single string
+			message = str(""" """).join(data)
+			self._sayStep(group, port, message)
+		else:
+			message = str(data, encoding='utf8')
+			self._sayStep(group, port, message)

--- a/multicast/send.py
+++ b/multicast/send.py
@@ -334,6 +334,10 @@ class McastSAY(multicast.mtool):
 			*args: Variable length argument list containing command-line arguments.
 			**kwargs: Arbitrary keyword arguments.
 
+		- group (str): Multicast group address (default: multicast._MCAST_DEFAULT_GROUP)
+		- port (int): Port number (default: multicast._MCAST_DEFAULT_PORT)
+		- data (str, list, or bytes): Message data to be sent. If set to ['-'], reads from stdin.
+
 		Returns:
 			tuple: A tuple containing a status indicator and result message.
 		"""
@@ -344,6 +348,11 @@ class McastSAY(multicast.mtool):
 			# Read from stdin in chunks
 			while True:
 				chunk = sys.stdin.read(1316)  # Read 1316 bytes at a time - matches read size
+				try:
+					chunk = sys.stdin.read(1316)  # Read 1316 bytes at a time - matches read size
+				except IOError as e:
+					print(f"Error reading from stdin: {e}", file=sys.stderr)
+					break
 				if not chunk:
 					break
 				self._sayStep(group, port, chunk)

--- a/tests/context.py
+++ b/tests/context.py
@@ -78,6 +78,15 @@ except ImportError as err:  # pragma: no branch
 
 
 try:
+	if 'string' not in sys.modules:
+		import string
+	else:  # pragma: no branch
+		string = sys.modules["""string"""]
+except ImportError as err:  # pragma: no branch
+	raise ModuleNotFoundError("[CWE-440] String Failed to import.") from err
+
+
+try:
 	if 'unittest' not in sys.modules:
 		import unittest
 	else:  # pragma: no branch

--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -31,7 +31,9 @@ try:
 	else:
 		from context import multicast  # pylint: disable=cyclic-import - skipcq: PYL-R0401
 		from context import unittest
+		from context import subprocess
 		from context import Process
+		from context import string
 		from hypothesis import given
 		from hypothesis import settings
 		from hypothesis import strategies as st
@@ -118,6 +120,34 @@ class HypothesisTestSuite(context.BasicUsageTestSuite):
 			context.debugtestError(err)
 			self.skipTest(fail_fixture)
 		self.assertTrue(theResult, fail_fixture)
+
+	@given(st.text(alphabet=string.ascii_letters + string.digits, min_size=3, max_size=15))
+	@settings(deadline=None)
+	def test_invalid_Error_WHEN_cli_called_GIVEN_invalid_fuzz_input(self, text):
+		"""Test case template for invalid fuzzed input to multicast CLI."""
+		theResult = False
+		if (self._thepython is not None):
+			try:
+				args = [
+					str(self._thepython),
+					str("-m"),
+					str("multicast"),
+					str(
+						text
+					)
+				]
+				theOutputtxt = context.checkPythonCommand(args, stderr=subprocess.STDOUT)
+				# or simply:
+				self.assertIsNotNone(theOutputtxt)
+				self.assertIn(str("invalid choice:"), str(theOutputtxt))
+				self.assertIn(str(text), str(theOutputtxt))
+				theResult = True
+			except Exception as err:
+				context.debugtestError(err)
+				err = None
+				del err  # skipcq - cleanup any error leaks early
+				theResult = False
+		assert theResult
 
 
 if __name__ == '__main__':

--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -124,8 +124,23 @@ class HypothesisTestSuite(context.BasicUsageTestSuite):
 	@given(st.text(alphabet=string.ascii_letters + string.digits, min_size=3, max_size=15))
 	@settings(deadline=None)
 	def test_invalid_Error_WHEN_cli_called_GIVEN_invalid_fuzz_input(self, text):
-		"""Test case template for invalid fuzzed input to multicast CLI."""
+		"""
+		Test the multicast CLI's response to invalid fuzzed input.
+
+		This test case uses Hypothesis to generate random strings of ASCII letters
+		and digits, then passes them as arguments to the multicast CLI. It verifies
+		that the CLI correctly identifies and reports these as invalid inputs.
+
+		Args:
+			text (str): A randomly generated string of ASCII letters and digits,
+				with length between 3 and 15 characters.
+
+		Assertions:
+			- The CLI output contains "invalid choice:" message
+			- The CLI output includes the invalid input text
+		"""
 		theResult = False
+		fail_fixture = str("""XZY? --> Multicast != error""")
 		if (self._thepython is not None):
 			try:
 				args = [
@@ -147,7 +162,7 @@ class HypothesisTestSuite(context.BasicUsageTestSuite):
 				err = None
 				del err  # skipcq - cleanup any error leaks early
 				theResult = False
-		assert theResult
+		self.assertTrue(theResult, fail_fixture)
 
 
 if __name__ == '__main__':

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -59,6 +59,8 @@ try:
 	else:
 		from context import multicast  # pylint: disable=cyclic-import - skipcq: PYL-R0401
 		from context import unittest
+		import io
+		from unittest.mock import patch
 		from context import subprocess
 		from context import Process
 except Exception as err:
@@ -379,6 +381,28 @@ class MulticastTestSuite(context.BasicUsageTestSuite):
 			theResult = False
 		self.assertTrue(theResult, fail_fixture)
 
+	def test_say_works_WHEN_using_stdin(self):
+		"""Tests the basic send with streamed input test case."""
+		theResult = False
+		fail_fixture = str("""STDIN --> SAY == error""")
+		_fixture_port_num = self._the_test_port
+		try:
+			say = multicast.send.McastSAY()
+			self.assertIsNotNone(say)
+			self.assertIsNotNone(_fixture_port_num)
+			test_input = "Test message from stdin"
+			self.assertIsNotNone(test_input)
+			with patch('sys.stdin', io.StringIO(test_input)):
+				self.assertIsNone(say.doStep(data=['-'], group='224.0.0.1', port=_fixture_port_num))
+			# Assert that the result is as expected
+			# You might need to modify this based on what _sayStep returns
+			theResult = True  # or whatever the expected output is
+		except Exception as err:
+			context.debugtestError(err)
+			self.skipTest(fail_fixture)
+			theResult = False
+		self.assertTrue(theResult, fail_fixture)
+
 	def test_recv_Errors_WHEN_say_not_used(self):
 		"""Tests the basic noop recv test"""
 		theResult = False
@@ -691,7 +715,7 @@ class BasicIntegrationTestSuite(context.BasicUsageTestSuite):
 		theResult = False
 		if (self._thepython is not None):
 			try:
-				for test_case in ["BAdInPut", "1", "exit"]:
+				for test_case in ["BAdInPut", int(1), "exit"]:
 					args = [
 						str(self._thepython),
 						str("-m"),


### PR DESCRIPTION
- [x] Contributes to #150 (NEW FEATURE)

Changes in file multicast/send.py:
 - def doStep(self, *args, **kwargs): Now takes dash "-" to mean read message from standard-input.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the ability to process various types of input for multicast messages, including reading from standard input and concatenating multiple data elements.
	- Added new test cases to validate the multicast command-line interface against invalid inputs and to test the behavior of the multicast `SAY` command with standard input.

- **Bug Fixes**
	- Improved error handling and data processing logic for the `data` parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->