### PR TITLE
[STYLE] Aligned '.flake8.ini' with CEP-8 and CEP-7 (- WIP #181 -)

### DIFF
--- a/.flake8.ini
+++ b/.flake8.ini
@@ -1,13 +1,14 @@
 [flake8]
-select = C,E,F,W,B,B950
+select = C,D,E,F,W,B,B950
 # Ignore specific warnings and errors according to CEP-8 style
-extend-ignore =
-    W191,  # Indentation contains tabs
-    W391,  # Blank line at end of file
-    E117,  # Over-indented
-    D208,  # Docstring is over-indented
-    D203,  # 1 blank line required before class docstring - CEP-7
-    D212,  # Multi-line docstring summary should start at the first line - CEP-7
+extend-ignore = E117,D203,D208,D212,W191,W391
+# CEP-8 Custom Exceptions:
+#    W191,  # Indentation contains tabs
+#    W391,  # Blank line at end of file
+#    E117,  # Over-indented
+#    D208,  # Docstring is over-indented
+#    D203,  # 1 blank line required before class docstring - CEP-7
+#    D212,  # Multi-line docstring summary should start at the first line - CEP-7
 # Ignore long lines as specified in CEP-8
 max-line-length = 100
 extend-exclude =
@@ -20,7 +21,7 @@ extend-exclude =
     # There's no value in checking tox directories
     .tox,
     # This contains our built stuff
-    build
+    build,
     # Nothing to find in node_modules, ignore them
     node_modules,
     # This contains our built package for PyPi


### PR DESCRIPTION
Changes in file .flake8.ini:
 - fixed regression
 - Aligned flake config as able to align with [CEP-8](https://gist.github.com/reactive-firewall/b7ee98df9e636a51806e62ef9c4ab161) and [CEP-7](https://gist.github.com/reactive-firewall/123b8a45f1bdeb064079e0524a29ec20)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated linter configuration to include additional style checks.
	- Streamlined the ignored warnings and errors list for clarity.
	- Adjusted exclusion settings for specific directories in the linter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->