### PR TITLE
Use double quotes around $GITHUB_OUTPUT in GitHub Actions workflows

### DIFF
--- a/.github/workflows/CI-BUILD.yml
+++ b/.github/workflows/CI-BUILD.yml
@@ -163,7 +163,7 @@ jobs:
       - id: check_status
         run: |
           if [[ "${{ needs.BUILD.result }}" == "success" && "${{ needs.BOOTSTRAP.result }}" == "success" ]]; then
-            echo "build_success=true" >> $GITHUB_OUTPUT
+            echo "build_success=true" >> "$GITHUB_OUTPUT"
           else
-            echo "build_success=false" >> $GITHUB_OUTPUT
+            echo "build_success=false" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/CI-MATs.yml
+++ b/.github/workflows/CI-MATs.yml
@@ -43,17 +43,17 @@ jobs:
       - id: check
         run: |
           if [[ "${{ github.event.workflow_run.conclusion }}" == "success" ]]; then
-            echo "should_run=true" >> $GITHUB_OUTPUT
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
           else
-            echo "should_run=false" >> $GITHUB_OUTPUT
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
           fi
       - id: get_env
         run: |
           ENV_VALUE=$(gh api "${{ github.event.workflow_run.artifacts_url }}" --jq '.environment')
           if [[ -n "$ENV_VALUE" ]]; then
-            echo "environment=$ENV_VALUE" >> $GITHUB_OUTPUT
+            echo "environment=$ENV_VALUE" >> "$GITHUB_OUTPUT"
           else
-            echo "environment=Experimenting" >> $GITHUB_OUTPUT  # Default fallback
+            echo "environment=Experimenting" >> "$GITHUB_OUTPUT"  # Default fallback
           fi
 
   MATS:
@@ -121,7 +121,7 @@ jobs:
       - id: check_status
         run: |
           if [[ "${{ needs.MATS.result }}" == "success" ]]; then
-            echo "mats_success=true" >> $GITHUB_OUTPUT
+            echo "mats_success=true" >> "$GITHUB_OUTPUT"
           else
-            echo "mats_success=false" >> $GITHUB_OUTPUT
+            echo "mats_success=false" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -42,17 +42,17 @@ jobs:
       - id: check
         run: |
           if [[ "${{ github.event.workflow_run.conclusion }}" == "success" ]]; then
-            echo "should_run=true" >> $GITHUB_OUTPUT
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
           else
-            echo "should_run=false" >> $GITHUB_OUTPUT
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
           fi
       - id: get_env
         run: |
           ENV_VALUE=$(gh api "${{ github.event.workflow_run.artifacts_url }}" --jq '.environment')
           if [[ -n "$ENV_VALUE" ]]; then
-            echo "environment=$ENV_VALUE" >> $GITHUB_OUTPUT
+            echo "environment=$ENV_VALUE" >> "$GITHUB_OUTPUT"
           else
-            echo "environment=Experimenting" >> $GITHUB_OUTPUT  # Default fallback
+            echo "environment=Experimenting" >> "$GITHUB_OUTPUT"  # Default fallback
           fi
 
 


### PR DESCRIPTION
# Impacted GHI

 - [x] Closes #266

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Refined internal automation commands to ensure robust handling of output values.
	- Enhanced the stability of build and testing workflows, preventing issues with parameters containing spaces or special characters.
	- These updates improve the consistency and reliability of our continuous integration processes without altering functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->