### PR TITLE
Implemented join step empty groups edge-case logic

### DIFF
--- a/multicast/recv.py
+++ b/multicast/recv.py
@@ -237,7 +237,7 @@ _mcast_recv_empty_join_warn_message = "\n".join([
 
 _mcast_recv_lazy_bind_warning_message = "\n".join([
 	"Lazy call to multicast.joinstep with unspecified bind group.",
-	f"Will bind to {multicast._MCAST_DEFAULT_BIND_IP}.",
+	f"Will bind to {multicast._MCAST_DEFAULT_BIND_IP}.",  # skipcq: PYL-W0212 - module ok
 	"Tip: Pass a value for bind_group to suppress this message",
 	"(such as 'bind_group=multicast._MCAST_DEFAULT_BIND_IP')",
 ])
@@ -279,7 +279,10 @@ def _validate_join_args(groups=None, port=None, iface=None, bind_group=None, iso
 				groups = [bind_group]
 	else:
 		if __debug__ and not bind_group:  # pragma: no branch
-			if (len(groups) == 1) and (groups[0] != multicast._MCAST_DEFAULT_BIND_IP):
+			# skipcq: PYL-W0212
+			if (len(groups) == 1) and (
+				groups[0] != multicast._MCAST_DEFAULT_BIND_IP  # skipcq: PYL-W0212 - module ok
+			):
 				warnings.warn(
 					_mcast_recv_lazy_bind_warning_message,
 					category=ResourceWarning,
@@ -375,6 +378,7 @@ def joinstep(groups, port, iface=None, bind_group=None, isock=None):
 	else:
 		sock = isock.dup()
 	try:
+		# skipcq: PYL-W0212
 		sock.bind((multicast._MCAST_DEFAULT_BIND_IP if bind_group is None else bind_group, port))
 		for group in groups:
 			mreq = _struct.pack(


### PR DESCRIPTION
# Patch Notes

 * Implements new logic as detailed in [GHI #317](https://github.com/reactive-firewall/multicast/issues/317#issuecomment-2781978468)
 
## Impacted GHI

 - [x] Closes #317

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added user-facing warnings to guide correct usage when joining multicast groups, including suggestions and examples for better usage patterns.
- **Improvements**
  - Enhanced validation of input parameters when joining multicast groups, with clearer feedback for invalid or suboptimal configurations.
  - Improved consistency in default binding behavior for multicast group operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->