### PR TITLE
Tweaked the comments in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -436,8 +436,8 @@ clean-docs: ./docs/ ./docs/Makefile
 	$(QUIET)$(WAIT) ;
 
 ./docs/:
-	$(QUIET)test -d "$@" || DO_FAIL="exit 77" ;  # set fail if can't verify directory
-	$(QUIET)test -e "$@" || DO_FAIL="exit 69" ;  # overwrite exitcode if does not exsist.
+	$(QUIET)test -d "$@" || DO_FAIL="exit 77" ;  # 77: Permission denied - can't verify directory.
+	$(QUIET)test -e "$@" || DO_FAIL="exit 69" ;  # 69: [Docs] Service unavailable - does not exist.
 	$(QUIET)$(DO_FAIL) ;
 
 ./docs/Makefile: ./docs/


### PR DESCRIPTION
# Patch Notes

## Impacted GHI

 - [x] Closes #239 -)


Changes in file Makefile:
 * minor change to comments

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved comments in the documentation build process to clarify the meaning of specific exit codes when directory checks fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->