### PR TITLE
[FEATURE] Initial implementation of the pipe option (- WIP #216 -)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ pip install multicast
 <details><summary>Other Methods</summary>
 
 There are many ways to install the module besides using `pip`, but unless you have a specific need,
-using `pip` is reccomended for most users.
+using `pip` is recommended for most users.
 
 ### PEP-668 and externally-managed-environment installs
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -102,11 +102,11 @@ I begin with it.
 CLI should work like so:
 
 ```plain
-multicast [-h|--help] [--use-std] [--daemon] (SAY|RECV|HEAR)
+multicast [[-h|--help]|[--version] [--use-std] [--daemon] (SAY|RECV|HEAR)
     [-h|--help]
     [--port PORT]
     [--iface IFACE]
-    [-m MESSAGE|--message MESSAGE]
+    [-m MESSAGE|--message MESSAGE|--pipe]
     [--group BIND_GROUP]
     [--groups [JOIN_MCAST_GROUPS ...]]
 ```
@@ -119,8 +119,9 @@ and echo functions of a 1-to-1 connection.
 The `SAY` command is used to send data messages via multicast datagrams.
 
 * Note: the `--message` flag is expected with the `SAY` command;
-  if not provided, it behaves like `NOOP`.
+  if neither `--pipe` nor `--messages` are provided, `SAY` behaves like `NOOP`.
 * Note: the `--daemon` flag has no effect on the `SAY` command.
+* Note: the `--pipe` option reads message from stdin (added in v2.1.0, equivalent to `--message -`).
 
 ### `RECV`
 

--- a/multicast/__init__.py
+++ b/multicast/__init__.py
@@ -590,6 +590,7 @@ class mtool(abc.ABC):
 			)
 			calling_parser_group.add_argument(
 				"--use-std", dest="is_std", default=False, action="store_true",
+				help="Use interactive command mode. Disabled by default."
 			)
 			calling_parser_group.add_argument(
 				"--daemon", dest="is_daemon", default=False, action="store_true",

--- a/multicast/send.py
+++ b/multicast/send.py
@@ -305,7 +305,8 @@ class McastSAY(multicast.mtool):
 				dest="groups",
 				help="multicast groups (ip addrs) to listen to join."
 			)
-			parser.add_argument(
+			msgGrp = parser.add_argument_group()
+			msgGrp.add_argument(
 				"-m",
 				"--message",
 				nargs="+",
@@ -313,7 +314,7 @@ class McastSAY(multicast.mtool):
 				default="PING from {name}: group: {group}, port: {port}",
 			)
 			# v2.0.9: Added the --pipe option
-			parser.add_argument(
+			msgGrp.add_argument(
 				"--pipe",
 				action="store_const",
 				const=["-"],

--- a/multicast/send.py
+++ b/multicast/send.py
@@ -312,6 +312,14 @@ class McastSAY(multicast.mtool):
 				dest="data",
 				default="PING from {name}: group: {group}, port: {port}",
 			)
+			# v2.0.9: Added the --pipe option
+			parser.add_argument(
+				"--pipe",
+				action="store_const",
+				const=["-"],
+				dest="data",
+				help="read message from stdin (equivalent to --message -)"
+			)
 
 	@staticmethod
 	def _sayStep(group, port, data):

--- a/tests/check_integration_coverage
+++ b/tests/check_integration_coverage
@@ -165,7 +165,7 @@ printf "%s\n\n" "Start of Integration Test one-shot:" >> ./"${LOG_FILE}" ; wait 
 ( sleep 1 ; ${COVERAGE_CMD} multicast --use-std RECV --port "${TEST_MCAST_PORT}" --groups "${TEST_MCAST_GROUP}" --group "${TEST_MCAST_GROUP}" 2>./"${ERR_FILE}" & sleep 6 ; kill -9 $! 2>/dev/null ) >> ./"${LOG_FILE}" & true ;
 
 for PCOUNT in $(seq 1 5) ; do
-	# Test message sending operations rappidly
+	# Test message sending operations rapidly
 	# shellcheck disable=SC2086
 	${COVERAGE_CMD} multicast SAY --port "${TEST_MCAST_PORT}" --group "${TEST_MCAST_GROUP}" --message "TEST from ${PCOUNT}" 2>/dev/null & : ;
 done ;

--- a/tests/check_integration_coverage
+++ b/tests/check_integration_coverage
@@ -189,6 +189,22 @@ ${COVERAGE_CMD} multicast SAY --port "${TEST_MCAST_PORT}" --group "${TEST_MCAST_
 wait ;
 printf "%s\n\n" "End of Integration Test daemon" >> ./"${LOG_FILE}" ; wait ;
 
+# test --pipe mode added in v2.1.0
+printf "%s\n\n" "Start of Integration Test pipe:" >> ./"${LOG_FILE}" ; wait ;
+# shellcheck disable=SC2086
+( sleep 1 ; ${COVERAGE_CMD} multicast --daemon HEAR --port "${TEST_MCAST_PORT}" --group "${TEST_MCAST_GROUP}" 2>./"${ERR_FILE}" & sleep 6 ; kill -9 $! 2>/dev/null ) >> ./"${LOG_FILE}" & true ;
+
+for NOISE_ID in $(seq 1 5) ; do
+	# shellcheck disable=SC2086
+	{ printf "%s\n" "TEST input from $NOISE_ID" | ${COVERAGE_CMD} multicast SAY --port "${TEST_MCAST_PORT}" --group "${TEST_MCAST_GROUP}" --pipe 2>/dev/null ;} & : ;
+done ;
+# shellcheck disable=SC2086
+printf "%s\n" "TEST input from $NOISE_ID" | ${COVERAGE_CMD} multicast SAY --port "${TEST_MCAST_PORT}" --group "${TEST_MCAST_GROUP}" --pipe 2>/dev/null & sleep 1 ;
+# shellcheck disable=SC2086
+${COVERAGE_CMD} multicast SAY --port "${TEST_MCAST_PORT}" --group "${TEST_MCAST_GROUP}" --message "STOP" 2>/dev/null ;
+wait ;
+printf "%s\n\n" "End of Integration Test pipe" >> ./"${LOG_FILE}" ; wait ;
+
 # cleanup from test-suite
 
 # shellcheck disable=SC2086

--- a/tests/check_integration_coverage
+++ b/tests/check_integration_coverage
@@ -165,8 +165,9 @@ printf "%s\n\n" "Start of Integration Test one-shot:" >> ./"${LOG_FILE}" ; wait 
 ( sleep 1 ; ${COVERAGE_CMD} multicast --use-std RECV --port "${TEST_MCAST_PORT}" --groups "${TEST_MCAST_GROUP}" --group "${TEST_MCAST_GROUP}" 2>./"${ERR_FILE}" & sleep 6 ; kill -9 $! 2>/dev/null ) >> ./"${LOG_FILE}" & true ;
 
 for PCOUNT in $(seq 1 5) ; do
+	# Test message sending operations rappidly
 	# shellcheck disable=SC2086
-	${COVERAGE_CMD} multicast SAY --port "${TEST_MCAST_PORT}" --group "${TEST_MCAST_GROUP}" --message "TEST from ${PCOUNT}" 2>/dev/null & sleep 1 ;
+	${COVERAGE_CMD} multicast SAY --port "${TEST_MCAST_PORT}" --group "${TEST_MCAST_GROUP}" --message "TEST from ${PCOUNT}" 2>/dev/null & : ;
 done ;
 # shellcheck disable=SC2086
 ${COVERAGE_CMD} multicast SAY --port "${TEST_MCAST_PORT}" --group "${TEST_MCAST_GROUP}" --message "STOP from $TEST_MCAST_GROUP" 2>/dev/null & sleep 1 ;
@@ -179,6 +180,7 @@ printf "%s\n\n" "Start of Integration Test daemon:" >> ./"${LOG_FILE}" ; wait ;
 ( sleep 1 ; ${COVERAGE_CMD} multicast --daemon HEAR --port "${TEST_MCAST_PORT}" --group "${TEST_MCAST_GROUP}" 2>./"${ERR_FILE}" & sleep 6 ; kill -9 $! 2>/dev/null ) >> ./"${LOG_FILE}" & true ;
 
 for PCOUNT in $(seq 1 5) ; do
+	# Test concurrent message sending operations, all to the same destination group
 	# shellcheck disable=SC2086
 	${COVERAGE_CMD} multicast SAY --port "${TEST_MCAST_PORT}" --group "${TEST_MCAST_GROUP}" --message "TEST from $PCOUNT" 2>/dev/null & : ;
 done ;
@@ -195,6 +197,7 @@ printf "%s\n\n" "Start of Integration Test pipe:" >> ./"${LOG_FILE}" ; wait ;
 ( sleep 1 ; ${COVERAGE_CMD} multicast --daemon HEAR --port "${TEST_MCAST_PORT}" --group "${TEST_MCAST_GROUP}" 2>./"${ERR_FILE}" & sleep 6 ; kill -9 $! 2>/dev/null ) >> ./"${LOG_FILE}" & true ;
 
 for NOISE_ID in $(seq 1 5) ; do
+	# Test concurrent message sending operations, each using piped input
 	# shellcheck disable=SC2086
 	{ printf "%s\n" "TEST input from $NOISE_ID" | ${COVERAGE_CMD} multicast SAY --port "${TEST_MCAST_PORT}" --group "${TEST_MCAST_GROUP}" --pipe 2>/dev/null ;} & : ;
 done ;

--- a/tests/check_spelling
+++ b/tests/check_spelling
@@ -151,7 +151,8 @@ declare -a SPECIFIC_TYPOS=(
 	"belone:belong"  # from #373
 	"subbclass:subclass"  # from #379
 	"repostory's:repository's"  # from #384
-	"boundry:boundary"  #from #384
+	"boundry:boundary"  # from #384
+	"rappidly:rapidly"  # from #392
 )
 
 function cleanup() {


### PR DESCRIPTION
# Patch Notes

 * **NEW** Introducing the `--pipe` flag for CLI usage, allows easier piping in scripts.

## Impacted GHI

 - [x] Closes #216
 - [ ] Opens #393

## Changelog

<details><summary>initial implementation of new '--pipe' option</summary>

Changes in file README.md:
 * updated docs with new option

Changes in file docs/USAGE.md:
 * updated usage docs for new '--pipe' option

Changes in file multicast/__init__.py:
 * related work

Changes in file multicast/send.py:
 * initial implementation of new '--pipe' option

Changes in file tests/check_integration_coverage:
 * related work for testing

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new `--pipe` command-line option for the SAY command, allowing messages to be read from standard input.
  - Updated CLI documentation to include the new `--pipe` and `--version` flags.

- **Documentation**
  - Clarified usage of the SAY command and updated descriptions for new and existing options.
  - Corrected a spelling mistake in the installation instructions.
  - Added notes about the introduction and equivalence of the `--pipe` option.

- **Tests**
  - Expanded integration tests to cover the new `--pipe` mode and improved concurrency testing.
  - Added a new known typo for spelling regression checks.

- **Style**
  - Improved help descriptions for command-line arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->