### PR TITLE
[FEATURE] Implemented initial upload template for coverage GHA (- WIP…

### DIFF
--- a/.github/actions/fetch-test-reporter/action.yml
+++ b/.github/actions/fetch-test-reporter/action.yml
@@ -14,6 +14,7 @@ inputs:
       rate limiting.
     default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
     required: true
+secrets:
   codeclimate-token:
     description: |
       The token used to authenticate when performing codeclimate API operations.
@@ -70,10 +71,10 @@ runs:
       if: ${{ !cancelled() && (steps.output_can_fetch.outputs.can_fetch == 'true') && (runner.os != 'Windows') && (github.repository == 'reactive-firewall/multicast') }}
       shell: bash
       env:
-        CODECLIMATE_REPO_TOKEN: ${{ github.server_url == 'https://github.com' && inputs.codeclimate-token || '' }}
-        CC_TEST_REPORTER_ID: ${{ github.server_url == 'https://github.com' && inputs.cc-test-reporter-id || '' }}
-        COVERALLS_REPO_TOKEN: ${{ github.server_url == 'https://github.com' && inputs.coveralls-token || '' }}
-        DEEPSOURCE_DSN: ${{ github.server_url == 'https://github.com' && inputs.deepsource-dsn || '' }}
+        CODECLIMATE_REPO_TOKEN: ${{ github.server_url == 'https://github.com' && secrets.codeclimate-token || '' }}
+        CC_TEST_REPORTER_ID: ${{ github.server_url == 'https://github.com' && secrets.cc-test-reporter-id || '' }}
+        COVERALLS_REPO_TOKEN: ${{ github.server_url == 'https://github.com' && secrets.coveralls-token || '' }}
+        DEEPSOURCE_DSN: ${{ github.server_url == 'https://github.com' && secrets.deepsource-dsn || '' }}
       run: |
         ${{ github.workspace }}/.github/tools/fetch-test-reporter/fetch-test-reporter || exit $?
     - name: "Evaluate Fetch Task"

--- a/.github/actions/purge-test-reporter/action.yml
+++ b/.github/actions/purge-test-reporter/action.yml
@@ -14,6 +14,7 @@ inputs:
       rate limiting.
     default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
     required: true
+secrets:
   codeclimate-token:
     description: |
       The token used to authenticate when performing codeclimate API operations.
@@ -70,10 +71,10 @@ runs:
       if: ${{ !cancelled() && (steps.output_can_purge.outputs.can_purge == 'true') && (runner.os != 'Windows') && (github.repository == 'reactive-firewall/multicast') }}
       shell: bash
       env:
-        CODECLIMATE_REPO_TOKEN: ${{ github.server_url == 'https://github.com' && inputs.codeclimate-token || '' }}
-        CC_TEST_REPORTER_ID: ${{ github.server_url == 'https://github.com' && inputs.cc-test-reporter-id || '' }}
-        COVERALLS_REPO_TOKEN: ${{ github.server_url == 'https://github.com' && inputs.coveralls-token || '' }}
-        DEEPSOURCE_DSN: ${{ github.server_url == 'https://github.com' && inputs.deepsource-dsn || '' }}
+        CODECLIMATE_REPO_TOKEN: ${{ github.server_url == 'https://github.com' && secrets.codeclimate-token || '' }}
+        CC_TEST_REPORTER_ID: ${{ github.server_url == 'https://github.com' && secrets.cc-test-reporter-id || '' }}
+        COVERALLS_REPO_TOKEN: ${{ github.server_url == 'https://github.com' && secrets.coveralls-token || '' }}
+        DEEPSOURCE_DSN: ${{ github.server_url == 'https://github.com' && secrets.deepsource-dsn || '' }}
       run: |
         ${{ github.workspace }}/.github/tools/fetch-test-reporter/purge-test-reporter || exit $?
     - name: "Evaluate Fetch Task"

--- a/.github/actions/test-reporter-upload/action.yml
+++ b/.github/actions/test-reporter-upload/action.yml
@@ -230,24 +230,14 @@ runs:
       shell: bash
       run: |
         if [[ "${OS}" != "unknown" ]] ; then
-          if [[ "${{ steps.output_upload_tools.outputs.can_upload_to_codecov }}" == "true" ]] ; then
-            THE_RESULT="success"
-          fi ;
-          if [[ "${{ steps.output_upload_tools.outputs.can_upload_to_codeclimate }}" == "true" ]] ; then
-            THE_RESULT="success"
-          fi ;
-          if [[ "${{ steps.output_upload_tools.outputs.can_upload_to_coveralls }}" == "true" ]] ; then
-            THE_RESULT="success"
-          fi ;
-          if [[ "${{ steps.output_upload_tools.outputs.can_upload_to_deepsource }}" == "true" ]] ; then
+          if [[ "${{ steps.output_upload_tools.outputs.can_upload_to_codecov }}" == "true" ]] || \
+             [[ "${{ steps.output_upload_tools.outputs.can_upload_to_codeclimate }}" == "true" ]] || \
+             [[ "${{ steps.output_upload_tools.outputs.can_upload_to_coveralls }}" == "true" ]] || \
+             [[ "${{ steps.output_upload_tools.outputs.can_upload_to_deepsource }}" == "true" ]] ; then
             THE_RESULT="success"
           else
-            if [[ "${THE_RESULT}" == "success" ]] ; then
-              THE_RESULT="success"
-            else
-              THE_RESULT="failure"
-            fi
-          fi ;
+            THE_RESULT="failure"
+          fi
         else
           THE_RESULT="skipped"
         fi

--- a/.github/actions/test-reporter-upload/action.yml
+++ b/.github/actions/test-reporter-upload/action.yml
@@ -40,14 +40,6 @@ inputs:
       - Linux
       - Windows
     required: true
-  token:
-    description: |
-      The token used to authenticate when performing GitHub API operations.
-      When running this action on github.com, the default value is sufficient. When running on
-      GHES, you can pass a personal access token for github.com if you are experiencing
-      rate limiting.
-    default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
-    required: true
 secrets:
   codeclimate-token:
     description: |
@@ -102,8 +94,8 @@ runs:
       id: output_sha
       shell: bash
       run: |
-        printf "sha=%s\n" $(git rev-parse --verify '${{ inputs.sha }}') >> "$GITHUB_OUTPUT"
-        printf "BUILD_SHA=%s\n" $(git rev-parse --verify '${{ inputs.sha }}') >> "$GITHUB_ENV"
+        printf "sha=%s\n" $(git rev-parse --verify HEAD) >> "$GITHUB_OUTPUT"
+        printf "BUILD_SHA=%s\n" $(git rev-parse --verify HEAD) >> "$GITHUB_ENV"
     - name: "Identify Python Version"
       id: output_python
       if: ${{ !cancelled() }}
@@ -129,7 +121,7 @@ runs:
           printf "os=%s\n" "${OS_INPUT}" >> "$GITHUB_OUTPUT"
           OS=${OS_INPUT}
         else
-          printf "os=%s\n" "${OS:-'unknown'}" >> "$GITHUB_OUTPUT"
+          printf "os=%s\n" "${OS:-unknown}" >> "$GITHUB_OUTPUT"
         fi
         printf "%s\n" "OS=${OS}" >> "$GITHUB_ENV"
     - name: "Prepare Artifact Name"
@@ -171,7 +163,7 @@ runs:
             if [[ -x "${BINDIR:-${LOCALBIN}}/deepsource" ]] ; then
               printf "can_upload_to_deepsource=true\n" >> "$GITHUB_OUTPUT"
               printf "::debug::%s\n" "Found ${BINDIR:-${LOCALBIN}}/deepsource"
-              printf "deepsource_executable=${BINDIR:-${LOCALBIN}}/deepsource\n" >> "$GITHUB_OUTPUT"
+              printf "deepsource_executable=%s\n" "${BINDIR:-${LOCALBIN}}/deepsource" >> "$GITHUB_OUTPUT"
             else
               printf "::warning, title='Missing tool':: %s\n" "Can't find deepsource tool."
               printf "can_upload_to_deepsource=false\n" >> "$GITHUB_OUTPUT"
@@ -181,7 +173,7 @@ runs:
             if [[ -x $(command -v coveralls) ]] ; then
               printf "can_upload_to_coveralls=true\n" >> "$GITHUB_OUTPUT"
               printf "::debug::%s %s\n" "Found" $(command -v coveralls)
-              printf "coveralls_executable=%s\n" $(command -v coveralls)" >> "$GITHUB_OUTPUT"
+              printf "coveralls_executable=%s\n" $(command -v coveralls) >> "$GITHUB_OUTPUT"
             else
               printf "::warning, title='Missing tool':: %s\n" "Can't find coveralls tool."
               printf "can_upload_to_coveralls=false\n" >> "$GITHUB_OUTPUT"
@@ -224,7 +216,7 @@ runs:
             rm -f coverage_codecov 2>/dev/null || true ; wait ;
             printf "\n\n" >> "${GITHUB_STEP_SUMMARY}"
           fi
-          if [[ -d "${{ github.workspace }}/test-reports/coverage.xml" ]] ; then
+          if [[ -f "${{ github.workspace }}/test-reports/coverage.xml" ]] ; then
             printf "can_upload_to_codecov=true\n" >> "$GITHUB_OUTPUT"
           else
             printf "can_upload_to_codecov=false\n" >> "$GITHUB_OUTPUT"
@@ -308,7 +300,7 @@ runs:
         CODECLIMATE_REPO_TOKEN: ${{ github.server_url == 'https://github.com' && secrets.codeclimate-token || '' }}
         CC_TEST_REPORTER_ID: ${{ github.server_url == 'https://github.com' && secrets.cc-test-reporter-id || '' }}
       run: |
-        if [[ "${{ input.tests-outcome }}" == "success" ]] ; then
+        if [[ "${{ inputs.tests-outcome }}" == "success" ]] ; then
           ./cc-test-reporter after-build --exit-code 0 || exit 1 ;
         else
           ./cc-test-reporter after-build --exit-code 1 || exit 1 ;
@@ -330,7 +322,7 @@ runs:
         COVERALLS_REPO_TOKEN: ${{ github.server_url == 'https://github.com' && secrets.coveralls-token || '' }}
         COVERALLS_TOOL: ${{ steps.output_upload_tools.outputs.coveralls_executable }}
       run: |
-        if [[ "${{ input.tests-outcome }}" == "success" ]] ; then
+        if [[ "${{ inputs.tests-outcome }}" == "success" ]] ; then
           ${COVERALLS_TOOL} report test-reports/coverage.xml --base-path="${{ github.workspace }}" --format=python --service-job-id=${{ github.run_id }} --parallel --job-flag='${{ steps.output_os.outputs.os }}-${{ steps.output_python.outputs.python-version }}' --build-number=${{ inputs.job_code }} || exit 1 ;
         else
           ${COVERALLS_TOOL} report test-reports/coverage.xml --base-path="${{ github.workspace }}" --allow-empty --format=python --service-job-id=${{ github.run_id }} --parallel --job-flag='${{ steps.output_os.outputs.os }}-${{ steps.output_python.outputs.python-version }}' --build-number=${{ inputs.job_code }} || exit 1 ;
@@ -341,7 +333,7 @@ runs:
       shell: bash
       run: |
         if [[ "${{ steps.output_can_upload.outputs.can_upload }}" == "true" ]] ; then
-          if [[ "${{ input.tests-outcome }}" == "success" ]] ; then
+          if [[ "${{ inputs.tests-outcome }}" == "success" ]] ; then
             THE_RESULT="success"
           else
             THE_RESULT="neutral"

--- a/.github/actions/test-reporter-upload/action.yml
+++ b/.github/actions/test-reporter-upload/action.yml
@@ -1,0 +1,357 @@
+---
+name: 'Upload Code Coverage with Tools'
+description: 'Upload results with various Code Coverage tools'
+author: 'Mr. Walls'
+branding:
+  icon: 'upload'
+  color: 'green'
+inputs:
+  tests-outcome:
+    description: |
+      The result outcome of the test that generated the coverage results.
+    type: choice
+    options:
+      - cancelled
+      - failure
+      - neutral
+      - success
+      - skipped
+      - timed_out
+    required: true
+  job_code:
+    description: |
+      The job-id of the test that generated the coverage results.
+    required: true
+  python-version:
+    description: |
+      The python version to use. The default is to use the value of the environment
+      variable 'PYTHON_VERSION'.
+    default: '3.12'
+    required: true
+  os:
+    description: |
+     When running this action on github.com, the default value is sufficient. When running on
+      GHES, you can pass the 'unknown' value to override this.
+    default: ${{ github.server_url == 'https://github.com' && runner.os || 'unknown' }}
+    type: choice
+    options:
+      - unknown
+      - macOS
+      - Linux
+      - Windows
+    required: true
+  token:
+    description: |
+      The token used to authenticate when performing GitHub API operations.
+      When running this action on github.com, the default value is sufficient. When running on
+      GHES, you can pass a personal access token for github.com if you are experiencing
+      rate limiting.
+    default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
+    required: true
+secrets:
+  codeclimate-token:
+    description: |
+      The token used to authenticate when performing codeclimate API operations.
+    default: ''
+    required: true
+  cc-test-reporter-id:
+    description: |
+      The id used to report tests when performing codeclimate API operations.
+    default: ''
+    required: true
+  deepsource-dsn:
+    description: |
+      The deepsource DSN when performing deepsource API operations.
+    default: ''
+    required: true
+  coveralls-token:
+    description: |
+      The coveralls token used when performing coveralls API operations.
+    default: ''
+    required: true
+  codecov-token:
+    description: |
+      The codecov token used when performing codecov API operations.
+    default: ''
+    required: true
+outputs:
+  sha:
+    description: "The SHA of the commit checked-out"
+    value: ${{ steps.output_sha.outputs.sha || 'HEAD' }}
+  can_upload:
+    description: "Can the upload tool even be used?"
+    value: ${{ steps.output_can_upload.outputs.can_upload || 'false' }}
+  status:
+    description: "The outcome of the coverage test reporter action."
+    value: ${{ steps.coverage_outcome.outputs.status || 'cancelled' }}
+  coverage_upload_codecov_outcome:
+    value: ${{ steps.coverage-codecov-upload.outcome || 'cancelled' }}
+  coverage_upload_codeclimate_outcome:
+    value: ${{ steps.coverage-codeclimate-upload.outcome || 'cancelled' }}
+  coverage_upload_deepsource_outcome:
+    value: ${{ steps.coverage-deepsource-upload.outcome || 'cancelled' }}
+  coverage_upload_coveralls_outcome:
+    value: ${{ steps.coverage-coveralls-upload.outcome || 'cancelled' }}
+  coverage_upload_artifact_outcome:
+    value: ${{ steps.coverage-reports-upload.outcome || 'cancelled' }}
+
+runs:
+  using: composite
+  steps:
+    - name: "Calculate Commit SHA"
+      id: output_sha
+      shell: bash
+      run: |
+        printf "sha=%s\n" $(git rev-parse --verify '${{ inputs.sha }}') >> "$GITHUB_OUTPUT"
+        printf "BUILD_SHA=%s\n" $(git rev-parse --verify '${{ inputs.sha }}') >> "$GITHUB_ENV"
+    - name: "Identify Python Version"
+      id: output_python
+      if: ${{ !cancelled() }}
+      env:
+        PYTHON_VERSION_INPUT: ${{ inputs.python-version }}
+      shell: bash
+      run: |
+        if [[ -n $PYTHON_VERSION_INPUT ]]; then
+          printf "python-version=%s\n" "${PYTHON_VERSION_INPUT}" >> "$GITHUB_OUTPUT"
+          PYTHON_VERSION=${PYTHON_VERSION_INPUT}
+        else
+          printf "python-version=%s\n" "${PYTHON_VERSION}" >> "$GITHUB_OUTPUT"
+        fi
+        printf "%s\n" "PYTHON_VERSION=${PYTHON_VERSION}" >> "$GITHUB_ENV"
+    - name: "Identify Operating System"
+      id: output_os
+      if: ${{ !cancelled() }}
+      env:
+        OS_INPUT: ${{ inputs.os }}
+      shell: bash
+      run: |
+        if [[ -n $OS_INPUT ]]; then
+          printf "os=%s\n" "${OS_INPUT}" >> "$GITHUB_OUTPUT"
+          OS=${OS_INPUT}
+        else
+          printf "os=%s\n" "${OS:-'unknown'}" >> "$GITHUB_OUTPUT"
+        fi
+        printf "%s\n" "OS=${OS}" >> "$GITHUB_ENV"
+    - name: "Prepare Artifact Name"
+      id: output_artifact_name
+      if: ${{ !cancelled() }}
+      shell: bash
+      run: |
+        if [[ "${OS}" != "Windows" ]] ; then
+          printf "artifact-name=%s\n" multicast-coverage-${BUILD_SHA}-part-$(uuidgen) >> "$GITHUB_OUTPUT"
+        else
+          printf "artifact-name=%s" multicast-coverage-${BUILD_SHA}-part- >> "$GITHUB_OUTPUT"
+          printf "%04x%04x-%04x-%04x-%04x-%04x%04x%04x\n" $RANDOM $RANDOM $RANDOM $(($RANDOM & 0x0fff | 0x4000)) $(($RANDOM & 0x3fff | 0x8000)) $RANDOM $RANDOM $RANDOM >> "$GITHUB_OUTPUT"
+        fi
+        printf "%s\n" "COV_STEP_SUMMARY=Coverage-Summary-Artifact-${OS}-${PYTHON_VERSION}.txt" >> "$GITHUB_ENV"
+    - name: "Check has upload Tools"
+      id: output_upload_tools
+      if: ${{ !cancelled() }}
+      shell: bash
+      run: |
+        if [[ "${OS}" != "unknown" ]] ; then
+          if [[ -x ${{ github.workspace }}/cc-test-reporter ]] ; then
+            printf "can_upload_to_codeclimate=true\n" >> "$GITHUB_OUTPUT"
+            printf "::debug::%s\n" "Found ${{ github.workspace }}/cc-test-reporter"
+          else
+            printf "::warning, title='Missing tool':: %s\n" "Can't find cc-test-reporter tool."
+            printf "can_upload_to_codeclimate=false\n" >> "$GITHUB_OUTPUT"
+          fi
+          LOCALBIN="${{ github.workspace }}/bin"
+          if [[ -d "${BINDIR:-${LOCALBIN}}" ]] ; then
+            printf "::debug::%s\n" "Found ${BINDIR:-${LOCALBIN}}"
+            if [[ -x "${BINDIR:-${LOCALBIN}}/coveralls" ]] ; then
+              printf "can_upload_to_coveralls=true\n" >> "$GITHUB_OUTPUT"
+              printf "::debug::%s\n" "Found ${BINDIR:-${LOCALBIN}}/coveralls"
+              printf "coveralls_executable=${BINDIR:-${LOCALBIN}}/coveralls\n" >> "$GITHUB_OUTPUT"
+            else
+              printf "::warning, title='Missing tool':: %s\n" "Can't find coveralls tool."
+              printf "can_upload_to_coveralls=false\n" >> "$GITHUB_OUTPUT"
+            fi
+            if [[ -x "${BINDIR:-${LOCALBIN}}/deepsource" ]] ; then
+              printf "can_upload_to_deepsource=true\n" >> "$GITHUB_OUTPUT"
+              printf "::debug::%s\n" "Found ${BINDIR:-${LOCALBIN}}/deepsource"
+              printf "deepsource_executable=${BINDIR:-${LOCALBIN}}/deepsource\n" >> "$GITHUB_OUTPUT"
+            else
+              printf "::warning, title='Missing tool':: %s\n" "Can't find deepsource tool."
+              printf "can_upload_to_deepsource=false\n" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            printf "::notice, title='Missing BINDIR':: %s\n" "Can't find ${BINDIR:-${LOCALBIN}}."
+            if [[ -x $(command -v coveralls) ]] ; then
+              printf "can_upload_to_coveralls=true\n" >> "$GITHUB_OUTPUT"
+              printf "::debug::%s %s\n" "Found" $(command -v coveralls)
+              printf "coveralls_executable=%s\n" $(command -v coveralls)" >> "$GITHUB_OUTPUT"
+            else
+              printf "::warning, title='Missing tool':: %s\n" "Can't find coveralls tool."
+              printf "can_upload_to_coveralls=false\n" >> "$GITHUB_OUTPUT"
+              printf "coveralls_executable=coveralls\n" >> "$GITHUB_OUTPUT"
+            fi
+            if [[ -x $(command -v deepsource) ]] ; then
+              printf "can_upload_to_deepsource=true\n" >> "$GITHUB_OUTPUT"
+              printf "::debug::%s %s\n" "Found" $(command -v deepsource)
+              printf "deepsource_executable=%s\n" $(command -v deepsource) >> "$GITHUB_OUTPUT"
+            else
+              printf "::warning, title='Missing tool':: %s\n" "Can't find deepsource tool."
+              printf "can_upload_to_deepsource=false\n" >> "$GITHUB_OUTPUT"
+              printf "deepsource_executable=deepsource\n" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+        else
+          printf "::warning, title='Missing tools':: %s\n" "Can't find any supported tool."
+          printf "can_upload_to_codeclimate=false\n" >> "$GITHUB_OUTPUT"
+          printf "can_upload_to_coveralls=false\n" >> "$GITHUB_OUTPUT"
+          printf "can_upload_to_deepsource=false\n" >> "$GITHUB_OUTPUT"
+        fi
+        if [[ -d "${{ github.workspace }}/test-reports" ]] ; then
+          if [[ ( -x $(command -v coverage3) ) ]] ; then
+            printf "\n" >> "${GITHUB_STEP_SUMMARY}"
+            coverage3 combine --keep --data-file=coverage_codecov ./.coverage.* 2>/dev/null || true
+            wait ;
+            coverage3 report -m --include=multicast/* --ignore-errors --data-file=coverage_codecov 2>/dev/null >> "${GITHUB_STEP_SUMMARY}" || true
+            if [[ ! ( -f "${{ github.workspace }}/test-reports/coverage.xml" ) ]] ; then
+              coverage3 xml -o "${{ github.workspace }}/test-reports/coverage.xml" --data-file=coverage_codecov --include=multicast/* 2>/dev/null || true
+            fi ;
+            rm -f coverage_codecov 2>/dev/null || true ; wait ;
+            printf "\n\n" >> "${GITHUB_STEP_SUMMARY}"
+          elif [[ ( -x $(command -v coverage) ) ]] ; then
+            coverage combine --keep --data-file=coverage_codecov ./.coverage.* 2>/dev/null || true
+            wait ;
+            coverage report -m --include=multicast/* --ignore-errors --data-file=coverage_codecov --format=markdown 2>/dev/null >> "${GITHUB_STEP_SUMMARY}" || true
+            if [[ ! ( -f "${{ github.workspace }}/test-reports/coverage.xml" ) ]] ; then
+              coverage xml -o "${{ github.workspace }}/test-reports/coverage.xml" --include=multicast/* --data-file=coverage_codecov 2>/dev/null || true
+            fi ;
+            rm -f coverage_codecov 2>/dev/null || true ; wait ;
+            printf "\n\n" >> "${GITHUB_STEP_SUMMARY}"
+          fi
+          if [[ -d "${{ github.workspace }}/test-reports/coverage.xml" ]] ; then
+            printf "can_upload_to_codecov=true\n" >> "$GITHUB_OUTPUT"
+          else
+            printf "can_upload_to_codecov=false\n" >> "$GITHUB_OUTPUT"
+          fi
+        else
+          printf "can_upload_to_codecov=false\n" >> "$GITHUB_OUTPUT"
+        fi
+    - name: "Check can upload"
+      id: output_can_upload
+      if: ${{ !cancelled() }}
+      shell: bash
+      run: |
+        if [[ "${OS}" != "unknown" ]] ; then
+          if [[ "${{ steps.output_upload_tools.outputs.can_upload_to_codecov }}" == "true" ]] ; then
+            THE_RESULT="success"
+          fi ;
+          if [[ "${{ steps.output_upload_tools.outputs.can_upload_to_codeclimate }}" == "true" ]] ; then
+            THE_RESULT="success"
+          fi ;
+          if [[ "${{ steps.output_upload_tools.outputs.can_upload_to_coveralls }}" == "true" ]] ; then
+            THE_RESULT="success"
+          fi ;
+          if [[ "${{ steps.output_upload_tools.outputs.can_upload_to_deepsource }}" == "true" ]] ; then
+            THE_RESULT="success"
+          else
+            if [[ "${THE_RESULT}" == "success" ]] ; then
+              THE_RESULT="success"
+            else
+              THE_RESULT="failure"
+            fi
+          fi ;
+        else
+          THE_RESULT="skipped"
+        fi
+        printf "status=%s\n" "${THE_RESULT}" >> "$GITHUB_OUTPUT"
+        if [[ "${THE_RESULT}" == "success" ]] ; then
+          printf "can_upload=true\n" >> "$GITHUB_OUTPUT"
+          exit 0
+        else
+          printf "can_upload=false\n" >> "$GITHUB_OUTPUT"
+          if [[ "${THE_RESULT}" == "failure" ]] ; then
+            exit 1
+          fi ;
+        fi
+    - name: check codecov config
+      id: check-codecov-config
+      if ${{ !cancelled() && (steps.output_can_upload.outputs.can_upload == 'true') && (steps.output_upload_tools.outputs.can_upload_to_codecov == 'true') }}
+      shell: bash
+      run: |
+        ${{ github.workspace }}/tests/check_codecov || exit 1
+    - name:  Upload ${{ steps.output_os.outputs.os }} Python ${{ steps.output_python.outputs.python-version }} coverage to Codecov
+      id: coverage-codecov-upload
+      if ${{ success() && (steps.output_can_upload.outputs.can_upload == 'true') && (steps.output_upload_tools.outputs.can_upload_to_codecov == 'true') }}
+      uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+      with:
+        token: ${{ secrets.codecov-token }}
+        job_code: ${{ inputs.job_code || '' }}
+        override_commit: ${{ steps.output_sha.outputs.sha }}
+        files: ./coverage.xml,./test-reports/coverage.xml
+        directory: ${{ github.workspace }}
+        flags: multicast
+        name: multicast-github-${{ steps.output_os.outputs.os }}-${{ steps.output_python.outputs.python-version }}-${{ steps.output_sha.outputs.sha }}
+        verbose: true
+        fail_ci_if_error: false
+    - name: Upload ${{ steps.output_os.outputs.os }} Python ${{ steps.output_python.outputs.python-version }} Artifact
+      id: coverage-reports-upload
+      if ${{ !cancelled() && (steps.output_can_upload.outputs.can_upload == 'true') }}
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: Test-Report-${{ steps.output_os.outputs.os }}-${{ steps.output_python.outputs.python-version }}-${{ steps.output_sha.outputs.sha }}
+        path: ./test-reports/
+        if-no-files-found: ignore
+        compression-level: 9
+        retention-days: 2
+        overwrite: true
+    - name: Upload ${{ steps.output_os.outputs.os }} Python ${{ steps.output_python.outputs.python-version }} coverage to code-climate
+      if: ${{ !cancelled() && (steps.output_can_upload.outputs.can_upload == 'true') && (steps.output_upload_tools.outputs.can_upload_to_codeclimate == 'true') && (steps.output_os.outputs.os != 'Windows') && (github.repository == 'reactive-firewall/multicast') }}
+      id: coverage-codeclimate-upload
+      shell: bash
+      env:
+        CODECLIMATE_REPO_TOKEN: ${{ github.server_url == 'https://github.com' && secrets.codeclimate-token || '' }}
+        CC_TEST_REPORTER_ID: ${{ github.server_url == 'https://github.com' && secrets.cc-test-reporter-id || '' }}
+      run: |
+        if [[ "${{ input.tests-outcome }}" == "success" ]] ; then
+          ./cc-test-reporter after-build --exit-code 0 || exit 1 ;
+        else
+          ./cc-test-reporter after-build --exit-code 1 || exit 1 ;
+        fi
+    - name: Upload ${{ steps.output_os.outputs.os }} Python ${{ steps.output_python.outputs.python-version }} coverage to deepsource
+      if: ${{ !cancelled() && (steps.output_can_upload.outputs.can_upload == 'true') && (steps.output_upload_tools.outputs.can_upload_to_deepsource == 'true') && (steps.output_os.outputs.os != 'Windows') && (github.repository == 'reactive-firewall/multicast') }}
+      id: coverage-deepsource-upload
+      shell: bash
+      env:
+        DEEPSOURCE_DSN: ${{ github.server_url == 'https://github.com' && secrets.deepsource-dsn || '' }}
+        DEEPSOURCE_TOOL: ${{ steps.output_upload_tools.outputs.deepsource_executable }}
+      run: |
+        ${DEEPSOURCE_TOOL} report --analyzer test-coverage --key python --value-file ./coverage.xml 2>/dev/null
+    - name: Upload ${{ steps.output_os.outputs.os }} Python ${{ steps.output_python.outputs.python-version }} coverage to coveralls
+      if: ${{ !cancelled() && (steps.output_can_upload.outputs.can_upload == 'true') && (steps.output_upload_tools.outputs.can_upload_to_coveralls == 'true') && (steps.output_os.outputs.os != 'Windows') && (github.repository == 'reactive-firewall/multicast') }}
+      id: coverage-coveralls-upload
+      shell: bash
+      env:
+        COVERALLS_REPO_TOKEN: ${{ github.server_url == 'https://github.com' && secrets.coveralls-token || '' }}
+        COVERALLS_TOOL: ${{ steps.output_upload_tools.outputs.coveralls_executable }}
+      run: |
+        if [[ "${{ input.tests-outcome }}" == "success" ]] ; then
+          ${COVERALLS_TOOL} report test-reports/coverage.xml --base-path="${{ github.workspace }}" --format=python --service-job-id=${{ github.run_id }} --parallel --job-flag='${{ steps.output_os.outputs.os }}-${{ steps.output_python.outputs.python-version }}' --build-number=${{ inputs.job_code }} || exit 1 ;
+        else
+          ${COVERALLS_TOOL} report test-reports/coverage.xml --base-path="${{ github.workspace }}" --allow-empty --format=python --service-job-id=${{ github.run_id }} --parallel --job-flag='${{ steps.output_os.outputs.os }}-${{ steps.output_python.outputs.python-version }}' --build-number=${{ inputs.job_code }} || exit 1 ;
+        fi
+    - name: "Evaluate Coverage Report Task"
+      id: coverage_outcome
+      if: ${{ !cancelled() }}
+      shell: bash
+      run: |
+        if [[ "${{ steps.output_can_upload.outputs.can_upload }}" == "true" ]] ; then
+          if [[ "${{ input.tests-outcome }}" == "success" ]] ; then
+            THE_RESULT="success"
+          else
+            THE_RESULT="neutral"
+          fi ;
+        else
+          THE_RESULT="skipped"
+        fi
+        printf "status=%s\n" "${THE_RESULT}" >> "$GITHUB_OUTPUT"
+        if [[ "${THE_RESULT}" == "failure" ]] ; then
+          exit 1
+        else
+          exit 0
+        fi

--- a/.github/actions/test-reporter-upload/action.yml
+++ b/.github/actions/test-reporter-upload/action.yml
@@ -271,13 +271,13 @@ runs:
         fi
     - name: check codecov config
       id: check-codecov-config
-      if ${{ !cancelled() && (steps.output_can_upload.outputs.can_upload == 'true') && (steps.output_upload_tools.outputs.can_upload_to_codecov == 'true') }}
+      if: ${{ !cancelled() && (steps.output_can_upload.outputs.can_upload == 'true') && (steps.output_upload_tools.outputs.can_upload_to_codecov == 'true') }}
       shell: bash
       run: |
         ${{ github.workspace }}/tests/check_codecov || exit 1
-    - name:  Upload ${{ steps.output_os.outputs.os }} Python ${{ steps.output_python.outputs.python-version }} coverage to Codecov
+    - name: Upload ${{ steps.output_os.outputs.os }} Python ${{ steps.output_python.outputs.python-version }} coverage to Codecov
       id: coverage-codecov-upload
-      if ${{ success() && (steps.output_can_upload.outputs.can_upload == 'true') && (steps.output_upload_tools.outputs.can_upload_to_codecov == 'true') }}
+      if: ${{ success() && (steps.output_can_upload.outputs.can_upload == 'true') && (steps.output_upload_tools.outputs.can_upload_to_codecov == 'true') }}
       uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
       with:
         token: ${{ secrets.codecov-token }}
@@ -291,7 +291,7 @@ runs:
         fail_ci_if_error: false
     - name: Upload ${{ steps.output_os.outputs.os }} Python ${{ steps.output_python.outputs.python-version }} Artifact
       id: coverage-reports-upload
-      if ${{ !cancelled() && (steps.output_can_upload.outputs.can_upload == 'true') }}
+      if: ${{ !cancelled() && (steps.output_can_upload.outputs.can_upload == 'true') }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: Test-Report-${{ steps.output_os.outputs.os }}-${{ steps.output_python.outputs.python-version }}-${{ steps.output_sha.outputs.sha }}

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -295,12 +295,12 @@ jobs:
         else
           THE_RESULT="failure"
         fi
-        if [[ "${{ steps.upload-test-tools.outputs.coverage_codeclimate_upload_outcome }}" != "failure" && "${THE_RESULT}" == "success" ]] ; then
+        if [[ "${{ steps.upload-test-tools.outputs.coverage_upload_codeclimate_outcome }}" != "failure" && "${THE_RESULT}" == "success" ]] ; then
           THE_RESULT="success"
         else
           THE_RESULT="failure"
         fi
-        if [[ "${{ steps.upload-test-tools.outputs.coverage_deepsource_upload_outcome }}" != "failure" && "${THE_RESULT}" == "success" ]] ; then
+        if [[ "${{ steps.upload-test-tools.outputs.coverage_upload_deepsource_outcome }}" != "failure" && "${THE_RESULT}" == "success" ]] ; then
           THE_RESULT="success"
         else
           THE_RESULT="failure"
@@ -352,19 +352,19 @@ jobs:
             printf "%s\n" "  * :black_square_button: Uploading unit-tests coverage report to CodeCov was skipped" >> "$COV_STEP_SUMMARY"
           fi
         fi
-        if [[ "${{ steps.upload-test-tools.outputs.coverage_codeclimate_upload_outcome }}" == "success" ]] ; then
+        if [[ "${{ steps.upload-test-tools.outputs.coverage_upload_codeclimate_outcome }}" == "success" ]] ; then
           printf "%s\n" "  * :arrow_up: Uploading unit-tests coverage report to codeclimate succeeded" >> "$COV_STEP_SUMMARY"
         else
-          if [[ "${{ steps.upload-test-tools.outputs.coverage_codeclimate_upload_outcome }}" == "failed" ]] ; then
+          if [[ "${{ steps.upload-test-tools.outputs.coverage_upload_codeclimate_outcome }}" == "failed" ]] ; then
             printf "%s\n" "  * :no_entry: Uploading unit-tests coverage report to codeclimate failed" >> "$COV_STEP_SUMMARY"
           else
             printf "%s\n" "  * :black_square_button: Uploading unit-tests coverage report to codeclimate was skipped" >> "$COV_STEP_SUMMARY"
           fi
         fi
-        if [[ "${{ steps.upload-test-tools.outputs.coverage_deepsource_upload_outcome }}" == "success" ]] ; then
+        if [[ "${{ steps.upload-test-tools.outputs.coverage_upload_deepsource_outcome }}" == "success" ]] ; then
           printf "%s\n" "  * :arrow_up: Uploading unit-tests coverage report to deepsource succeeded" >> "$COV_STEP_SUMMARY"
         else
-          if [[ "${{ steps.upload-test-tools.outputs.coverage_deepsource_upload_outcome }}" == "failed" ]] ; then
+          if [[ "${{ steps.upload-test-tools.outputs.coverage_upload_deepsource_outcome }}" == "failed" ]] ; then
             printf "%s\n" "  * :no_entry: Uploading unit-tests coverage report to deepsource failed" >> "$COV_STEP_SUMMARY"
           else
             printf "%s\n" "  * :black_square_button: Uploading unit-tests coverage report to deepsource was skipped" >> "$COV_STEP_SUMMARY"
@@ -559,12 +559,12 @@ jobs:
         else
           THE_RESULT="failure"
         fi
-        if [[ "${{ steps.upload-test-tools.outputs.coverage_codeclimate_upload_outcome }}" != "failure" && "${THE_RESULT}" == "success" ]] ; then
+        if [[ "${{ steps.upload-test-tools.outputs.coverage_upload_codeclimate_outcome }}" != "failure" && "${THE_RESULT}" == "success" ]] ; then
           THE_RESULT="success"
         else
           THE_RESULT="failure"
         fi
-        if [[ "${{ steps.upload-test-tools.outputs.coverage_deepsource_upload_outcome }}" != "failure" && "${THE_RESULT}" == "success" ]] ; then
+        if [[ "${{ steps.upload-test-tools.outputs.coverage_upload_deepsource_outcome }}" != "failure" && "${THE_RESULT}" == "success" ]] ; then
           THE_RESULT="success"
         else
           THE_RESULT="failure"
@@ -607,19 +607,19 @@ jobs:
             printf "%s\n" "  * :black_square_button: Uploading Doctests coverage report to CodeCov was skipped" >> "$DOC_STEP_SUMMARY"
           fi
         fi
-        if [[ "${{ steps.upload-test-tools.outputs.coverage_codeclimate_upload_outcome }}" == "success" ]] ; then
+        if [[ "${{ steps.upload-test-tools.outputs.coverage_upload_codeclimate_outcome }}" == "success" ]] ; then
           printf "%s\n" "  * :arrow_up: Uploading Doctests coverage report to codeclimate succeeded" >> "$DOC_STEP_SUMMARY"
         else
-          if [[ "${{ steps.upload-test-tools.outputs.coverage_codeclimate_upload_outcome }}" == "failed" ]] ; then
+          if [[ "${{ steps.upload-test-tools.outputs.coverage_upload_codeclimate_outcome }}" == "failed" ]] ; then
             printf "%s\n" "  * :no_entry: Uploading Doctests coverage report to codeclimate failed" >> "$DOC_STEP_SUMMARY"
           else
             printf "%s\n" "  * :black_square_button: Uploading Doctests coverage report to codeclimate was skipped" >> "$DOC_STEP_SUMMARY"
           fi
         fi
-        if [[ "${{ steps.upload-test-tools.outputs.coverage_deepsource_upload_outcome }}" == "success" ]] ; then
+        if [[ "${{ steps.upload-test-tools.outputs.coverage_upload_deepsource_outcome }}" == "success" ]] ; then
           printf "%s\n" "  * :arrow_up: Uploading Doctests coverage report to deepsource succeeded" >> "$DOC_STEP_SUMMARY"
         else
-          if [[ "${{ steps.upload-test-tools.outputs.coverage_deepsource_upload_outcome }}" == "failed" ]] ; then
+          if [[ "${{ steps.upload-test-tools.outputs.coverage_upload_deepsource_outcome }}" == "failed" ]] ; then
             printf "%s\n" "  * :no_entry: Uploading Doctests coverage report to deepsource failed" >> "$DOC_STEP_SUMMARY"
           else
             printf "%s\n" "  * :black_square_button: Uploading Doctests coverage report to deepsource was skipped" >> "$DOC_STEP_SUMMARY"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -246,7 +246,6 @@ jobs:
         os: ${{ runner.os }}
         python-version: ${{ matrix.python-version }}
         job_code: ${{ needs.check_mats.outputs.tests_id }}
-        token: ${{ github.server_url == 'https://github.com' && github.token || '' }}
       secrets:
         deepsource-dsn: ${{ github.server_url == 'https://github.com' && secrets.DEEPSOURCE_DSN || '' }}
         coveralls-token: ${{ github.server_url == 'https://github.com' && secrets.COVERALLS_REPO_TOKEN || '' }}
@@ -296,7 +295,7 @@ jobs:
         else
           THE_RESULT="failure"
         fi
-        if [[ "${{ steps.steps.upload-test-tools.outputs.coverage_codeclimate_upload_outcome }}" != "failure" && "${THE_RESULT}" == "success" ]] ; then
+        if [[ "${{ steps.upload-test-tools.outputs.coverage_codeclimate_upload_outcome }}" != "failure" && "${THE_RESULT}" == "success" ]] ; then
           THE_RESULT="success"
         else
           THE_RESULT="failure"
@@ -353,10 +352,10 @@ jobs:
             printf "%s\n" "  * :black_square_button: Uploading unit-tests coverage report to CodeCov was skipped" >> "$COV_STEP_SUMMARY"
           fi
         fi
-        if [[ "${{ steps.steps.upload-test-tools.outputs.coverage_codeclimate_upload_outcome }}" == "success" ]] ; then
+        if [[ "${{ steps.upload-test-tools.outputs.coverage_codeclimate_upload_outcome }}" == "success" ]] ; then
           printf "%s\n" "  * :arrow_up: Uploading unit-tests coverage report to codeclimate succeeded" >> "$COV_STEP_SUMMARY"
         else
-          if [[ "${{ steps.steps.upload-test-tools.outputs.coverage_codeclimate_upload_outcome }}" == "failed" ]] ; then
+          if [[ "${{ steps.upload-test-tools.outputs.coverage_codeclimate_upload_outcome }}" == "failed" ]] ; then
             printf "%s\n" "  * :no_entry: Uploading unit-tests coverage report to codeclimate failed" >> "$COV_STEP_SUMMARY"
           else
             printf "%s\n" "  * :black_square_button: Uploading unit-tests coverage report to codeclimate was skipped" >> "$COV_STEP_SUMMARY"
@@ -516,7 +515,6 @@ jobs:
         os: ${{ runner.os }}
         python-version: ${{ matrix.python-version }}
         job_code: ${{ needs.check_mats.outputs.tests_id }}
-        token: ${{ github.server_url == 'https://github.com' && github.token || '' }}
       secrets:
         deepsource-dsn: ${{ github.server_url == 'https://github.com' && secrets.DEEPSOURCE_DSN || '' }}
         coveralls-token: ${{ github.server_url == 'https://github.com' && secrets.COVERALLS_REPO_TOKEN || '' }}

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -155,9 +155,9 @@ jobs:
       coverage_test_outcome: ${{ steps.coverage_tests.outcome }}
       coverage_upload_unitests_outcome: ${{ steps.coverage-unittests-codecov-upload.outcome }}
       coverage_upload_codecov_outcome: ${{ steps.coverage-project-codecov-upload.outcome }}
-      coverage_upload_codeclimate_outcome: ${{ steps.coverage-codeclimate-upload.outcome }}
-      coverage_upload_deepsource_outcome: ${{ steps.coverage-deepsource-upload.outcome }}
-      coverage_upload_artifact_outcome: ${{ steps.coverage-reports-upload.outcome }}
+      coverage_upload_codeclimate_outcome: ${{ steps.upload-test-tools.outputs.coverage_upload_codeclimate_outcome }}
+      coverage_upload_deepsource_outcome: ${{ steps.upload-test-tools.outputs.coverage_upload_deepsource_outcome }}
+      coverage_upload_artifact_outcome: ${{ steps.upload-test-tools.outputs.coverage_upload_artifact_outcome }}
       coverage_artifact_url: ${{ steps.coverage-reports-upload.outputs.artifact-url }}
       coverage_artifact_id: ${{ steps.coverage-reports-upload.outputs.artifact-id }}
       coverage_artifact_digest: ${{ steps.coverage-reports-upload.outputs.artifact-digest }}
@@ -189,6 +189,7 @@ jobs:
       uses: ./.github/actions/fetch-test-reporter
       with:
         token: ${{ github.server_url == 'https://github.com' && github.token || '' }}
+      secrets:
         deepsource-dsn: ${{ github.server_url == 'https://github.com' && secrets.DEEPSOURCE_DSN || '' }}
         coveralls-token: ${{ github.server_url == 'https://github.com' && secrets.COVERALLS_REPO_TOKEN || '' }}
         codeclimate-token: ${{ github.server_url == 'https://github.com' && secrets.CODECLIMATE_REPO_TOKEN || '' }}
@@ -237,33 +238,28 @@ jobs:
         name: Test-Report-${{ matrix.os }}-${{ matrix.python-version }}
         path: ./test-reports/
         if-no-files-found: ignore
-    - name: code-climate for ${{ matrix.python-version }} on ${{ matrix.os }}
-      if: ${{ !cancelled() && runner.os != 'Windows' }}
-      id: coverage-codeclimate-upload
-      shell: bash
-      env:
-        CODECLIMATE_REPO_TOKEN: ${{ secrets.CODECLIMATE_REPO_TOKEN }}
-        CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-      run: |
-        if [[ "${{ steps.coverage_tests.outcome }}" == "success" ]] ; then
-          ./cc-test-reporter after-build --exit-code 0 || exit 1 ;
-        else
-          ./cc-test-reporter after-build --exit-code 1 || true ;
-        fi
-    - name: deepsource for ${{ matrix.python-version }} on ${{ matrix.os }}
-      if: ${{ !cancelled() && runner.os != 'Windows' }}
-      id: coverage-deepsource-upload
-      shell: bash
-      env:
-        DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
-      run: |
-        ./bin/deepsource report --analyzer test-coverage --key python --value-file ./coverage.xml 2>/dev/null || true ;
+    - id: upload-test-tools
+      if: ${{ !cancelled() }}
+      uses: ./.github/actions/test-reporter-upload
+      with:
+        sha: ${{ needs.check_mats.outputs.build_sha }}
+        os: ${{ runner.os }}
+        python-version: ${{ matrix.python-version }}
+        job_code: ${{ needs.check_mats.outputs.tests_id }}
+        token: ${{ github.server_url == 'https://github.com' && github.token || '' }}
+      secrets:
+        deepsource-dsn: ${{ github.server_url == 'https://github.com' && secrets.DEEPSOURCE_DSN || '' }}
+        coveralls-token: ${{ github.server_url == 'https://github.com' && secrets.COVERALLS_REPO_TOKEN || '' }}
+        codeclimate-token: ${{ github.server_url == 'https://github.com' && secrets.CODECLIMATE_REPO_TOKEN || '' }}
+        cc-test-reporter-id: ${{ github.server_url == 'https://github.com' && secrets.CC_TEST_REPORTER_ID || '' }}
+        codecov-token: ${{ github.server_url == 'https://github.com' && secrets.CODECOV_TOKEN || '' }}
     - name: Finalize coverage tools for ${{ matrix.python-version }} on ${{ matrix.os }}
       id: purge-test-tools
       if: ${{ !cancelled() && runner.os != 'Windows' }}
       uses: ./.github/actions/purge-test-reporter
       with:
         token: ${{ github.server_url == 'https://github.com' && github.token || '' }}
+      secrets:
         deepsource-dsn: ${{ github.server_url == 'https://github.com' && secrets.DEEPSOURCE_DSN || '' }}
         coveralls-token: ${{ github.server_url == 'https://github.com' && secrets.COVERALLS_REPO_TOKEN || '' }}
         codeclimate-token: ${{ github.server_url == 'https://github.com' && secrets.CODECLIMATE_REPO_TOKEN || '' }}
@@ -300,12 +296,12 @@ jobs:
         else
           THE_RESULT="failure"
         fi
-        if [[ "${{ steps.coverage-codeclimate-upload.outcome }}" != "failure" && "${THE_RESULT}" == "success" ]] ; then
+        if [[ "${{ steps.steps.upload-test-tools.outputs.coverage_codeclimate_upload_outcome }}" != "failure" && "${THE_RESULT}" == "success" ]] ; then
           THE_RESULT="success"
         else
           THE_RESULT="failure"
         fi
-        if [[ "${{ steps.coverage-deepsource-upload.outcome }}" != "failure" && "${THE_RESULT}" == "success" ]] ; then
+        if [[ "${{ steps.upload-test-tools.outputs.coverage_deepsource_upload_outcome }}" != "failure" && "${THE_RESULT}" == "success" ]] ; then
           THE_RESULT="success"
         else
           THE_RESULT="failure"
@@ -357,19 +353,19 @@ jobs:
             printf "%s\n" "  * :black_square_button: Uploading unit-tests coverage report to CodeCov was skipped" >> "$COV_STEP_SUMMARY"
           fi
         fi
-        if [[ "${{ steps.coverage-codeclimate-upload.outcome }}" == "success" ]] ; then
+        if [[ "${{ steps.steps.upload-test-tools.outputs.coverage_codeclimate_upload_outcome }}" == "success" ]] ; then
           printf "%s\n" "  * :arrow_up: Uploading unit-tests coverage report to codeclimate succeeded" >> "$COV_STEP_SUMMARY"
         else
-          if [[ "${{ steps.coverage-codeclimate-upload.outcome }}" == "failed" ]] ; then
+          if [[ "${{ steps.steps.upload-test-tools.outputs.coverage_codeclimate_upload_outcome }}" == "failed" ]] ; then
             printf "%s\n" "  * :no_entry: Uploading unit-tests coverage report to codeclimate failed" >> "$COV_STEP_SUMMARY"
           else
             printf "%s\n" "  * :black_square_button: Uploading unit-tests coverage report to codeclimate was skipped" >> "$COV_STEP_SUMMARY"
           fi
         fi
-        if [[ "${{ steps.coverage-deepsource-upload.outcome }}" == "success" ]] ; then
+        if [[ "${{ steps.upload-test-tools.outputs.coverage_deepsource_upload_outcome }}" == "success" ]] ; then
           printf "%s\n" "  * :arrow_up: Uploading unit-tests coverage report to deepsource succeeded" >> "$COV_STEP_SUMMARY"
         else
-          if [[ "${{ steps.coverage-deepsource-upload.outcome }}" == "failed" ]] ; then
+          if [[ "${{ steps.upload-test-tools.outputs.coverage_deepsource_upload_outcome }}" == "failed" ]] ; then
             printf "%s\n" "  * :no_entry: Uploading unit-tests coverage report to deepsource failed" >> "$COV_STEP_SUMMARY"
           else
             printf "%s\n" "  * :black_square_button: Uploading unit-tests coverage report to deepsource was skipped" >> "$COV_STEP_SUMMARY"
@@ -483,6 +479,7 @@ jobs:
       uses: ./.github/actions/fetch-test-reporter
       with:
         token: ${{ github.server_url == 'https://github.com' && github.token || '' }}
+      secrets:
         deepsource-dsn: ${{ github.server_url == 'https://github.com' && secrets.DEEPSOURCE_DSN || '' }}
         coveralls-token: ${{ github.server_url == 'https://github.com' && secrets.COVERALLS_REPO_TOKEN || '' }}
         codeclimate-token: ${{ github.server_url == 'https://github.com' && secrets.CODECLIMATE_REPO_TOKEN || '' }}
@@ -511,33 +508,28 @@ jobs:
         name: DocTest-Report-${{ matrix.os }}-${{ matrix.python-version }}
         path: ./test-reports/
         if-no-files-found: ignore
-    - name: code-climate for ${{ matrix.python-version }} on ${{ matrix.os }}
-      if: ${{ !cancelled() && runner.os != 'Windows' }}
-      id: doctests-codeclimate-upload
-      shell: bash
-      env:
-        CODECLIMATE_REPO_TOKEN: ${{ secrets.CODECLIMATE_REPO_TOKEN }}
-        CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-      run: |
-        if [[ "${{ steps.doctests-main.outcome }}" == "success" ]] ; then
-          ./cc-test-reporter after-build --exit-code 0 || exit 1 ;
-        else
-          ./cc-test-reporter after-build --exit-code 1 || true ;
-        fi
-    - name: deepsource for ${{ matrix.python-version }} on ${{ matrix.os }}
-      if: ${{ !cancelled() && runner.os != 'Windows' }}
-      id: doctests-deepsource-upload
-      shell: bash
-      env:
-        DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
-      run: |
-        ./bin/deepsource report --analyzer test-coverage --key python --value-file ./coverage.xml 2>/dev/null || true ;
+    - id: upload-test-tools
+      if: ${{ !cancelled() }}
+      uses: ./.github/actions/test-reporter-upload
+      with:
+        sha: ${{ needs.check_mats.outputs.build_sha }}
+        os: ${{ runner.os }}
+        python-version: ${{ matrix.python-version }}
+        job_code: ${{ needs.check_mats.outputs.tests_id }}
+        token: ${{ github.server_url == 'https://github.com' && github.token || '' }}
+      secrets:
+        deepsource-dsn: ${{ github.server_url == 'https://github.com' && secrets.DEEPSOURCE_DSN || '' }}
+        coveralls-token: ${{ github.server_url == 'https://github.com' && secrets.COVERALLS_REPO_TOKEN || '' }}
+        codeclimate-token: ${{ github.server_url == 'https://github.com' && secrets.CODECLIMATE_REPO_TOKEN || '' }}
+        cc-test-reporter-id: ${{ github.server_url == 'https://github.com' && secrets.CC_TEST_REPORTER_ID || '' }}
+        codecov-token: ${{ github.server_url == 'https://github.com' && secrets.CODECOV_TOKEN || '' }}
     - name: Finalize coverage tools for ${{ matrix.python-version }} on ${{ matrix.os }}
       id: purge-doctest-test-tools
       if: ${{ !cancelled() && runner.os != 'Windows' }}
       uses: ./.github/actions/purge-test-reporter
       with:
         token: ${{ github.server_url == 'https://github.com' && github.token || '' }}
+      secrets:
         deepsource-dsn: ${{ github.server_url == 'https://github.com' && secrets.DEEPSOURCE_DSN || '' }}
         coveralls-token: ${{ github.server_url == 'https://github.com' && secrets.COVERALLS_REPO_TOKEN || '' }}
         codeclimate-token: ${{ github.server_url == 'https://github.com' && secrets.CODECLIMATE_REPO_TOKEN || '' }}
@@ -569,12 +561,12 @@ jobs:
         else
           THE_RESULT="failure"
         fi
-        if [[ "${{ steps.doctests-codeclimate-upload.outcome }}" != "failure" && "${THE_RESULT}" == "success" ]] ; then
+        if [[ "${{ steps.upload-test-tools.outputs.coverage_codeclimate_upload_outcome }}" != "failure" && "${THE_RESULT}" == "success" ]] ; then
           THE_RESULT="success"
         else
           THE_RESULT="failure"
         fi
-        if [[ "${{ steps.doctests-deepsource-upload.outcome }}" != "failure" && "${THE_RESULT}" == "success" ]] ; then
+        if [[ "${{ steps.upload-test-tools.outputs.coverage_deepsource_upload_outcome }}" != "failure" && "${THE_RESULT}" == "success" ]] ; then
           THE_RESULT="success"
         else
           THE_RESULT="failure"
@@ -617,19 +609,19 @@ jobs:
             printf "%s\n" "  * :black_square_button: Uploading Doctests coverage report to CodeCov was skipped" >> "$DOC_STEP_SUMMARY"
           fi
         fi
-        if [[ "${{ steps.doctests-codeclimate-upload.outcome }}" == "success" ]] ; then
+        if [[ "${{ steps.upload-test-tools.outputs.coverage_codeclimate_upload_outcome }}" == "success" ]] ; then
           printf "%s\n" "  * :arrow_up: Uploading Doctests coverage report to codeclimate succeeded" >> "$DOC_STEP_SUMMARY"
         else
-          if [[ "${{ steps.doctests-codeclimate-upload.outcome }}" == "failed" ]] ; then
+          if [[ "${{ steps.upload-test-tools.outputs.coverage_codeclimate_upload_outcome }}" == "failed" ]] ; then
             printf "%s\n" "  * :no_entry: Uploading Doctests coverage report to codeclimate failed" >> "$DOC_STEP_SUMMARY"
           else
             printf "%s\n" "  * :black_square_button: Uploading Doctests coverage report to codeclimate was skipped" >> "$DOC_STEP_SUMMARY"
           fi
         fi
-        if [[ "${{ steps.doctests-deepsource-upload.outcome }}" == "success" ]] ; then
+        if [[ "${{ steps.upload-test-tools.outputs.coverage_deepsource_upload_outcome }}" == "success" ]] ; then
           printf "%s\n" "  * :arrow_up: Uploading Doctests coverage report to deepsource succeeded" >> "$DOC_STEP_SUMMARY"
         else
-          if [[ "${{ steps.doctests-deepsource-upload.outcome }}" == "failed" ]] ; then
+          if [[ "${{ steps.upload-test-tools.outputs.coverage_deepsource_upload_outcome }}" == "failed" ]] ; then
             printf "%s\n" "  * :no_entry: Uploading Doctests coverage report to deepsource failed" >> "$DOC_STEP_SUMMARY"
           else
             printf "%s\n" "  * :black_square_button: Uploading Doctests coverage report to deepsource was skipped" >> "$DOC_STEP_SUMMARY"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -242,7 +242,7 @@ jobs:
       if: ${{ !cancelled() }}
       uses: ./.github/actions/test-reporter-upload
       with:
-        sha: ${{ needs.check_mats.outputs.build_sha }}
+        tests-outcome: ${{ steps.coverage_tests.outcome }}
         os: ${{ runner.os }}
         python-version: ${{ matrix.python-version }}
         job_code: ${{ needs.check_mats.outputs.tests_id }}
@@ -511,7 +511,7 @@ jobs:
       if: ${{ !cancelled() }}
       uses: ./.github/actions/test-reporter-upload
       with:
-        sha: ${{ needs.check_mats.outputs.build_sha }}
+        tests-outcome: ${{ steps.doctests-main.outcome }}
         os: ${{ runner.os }}
         python-version: ${{ matrix.python-version }}
         job_code: ${{ needs.check_mats.outputs.tests_id }}

--- a/tests/check_codecov
+++ b/tests/check_codecov
@@ -99,12 +99,21 @@ check_command gpgv ;
 check_command shasum ;
 check_command shlock ;
 
-# sorry no windows support here
-if [[ $( \uname -s ) == "*arwin" ]] ; then
-	CI_OS="macos"
-else
-	CI_OS="linux"
-fi
+# Detect the operating system
+case "$( command uname -s )" in
+	*arwin)
+		CI_OS="macos"
+		;;
+	Linux)
+		CI_OS="linux"
+		;;
+	*)
+		# assume windows
+		printf 'Unsupported OS\n' >&2 ;
+		CI_OS="windows"
+		;;
+esac
+
 
 function cleanup() {
 	# shellcheck disable=SC2317
@@ -139,7 +148,7 @@ fi
 
 # this is how test files are found:
 
-# THIS IS THE ACTUAL TEST DIR USED (update _TEST_ROOT_DIR as needed)
+# THIS IS THE ACTUAL GIT DIR USED (update _TEST_ROOT_DIR as needed)
 if _TEST_ROOT_DIR=$(git rev-parse --show-superproject-working-tree 2>/dev/null); then
 	if [ -z "${_TEST_ROOT_DIR}" ]; then
 		_TEST_ROOT_DIR=$(git rev-parse --show-toplevel 2>/dev/null)
@@ -149,12 +158,9 @@ else
 	EXIT_CODE=40
 fi
 
-# This File  MUST BE GIT-IGNORED
-# to be SAFELY USED to store Tokens and env vars (update logic as needed)
-if [[ ( -r ./codecov_env ) ]] ; then
-	# shellcheck disable=SC1091
-	source ./codecov_env 2>/dev/null || true ;
-fi
+#########################
+# actual Work starts here
+#########################
 
 if [[ ( -r ./codecov.yml ) ]] ; then
 	curl -X POST --data-binary @- https://codecov.io/validate <codecov.yml 2>/dev/null || EXIT_CODE=6
@@ -164,52 +170,43 @@ if [[ ( -r ./.codecov.yml ) ]] ; then
 fi
 
 
-#########################
-# actual Work starts here
-#########################
-curl -fLso codecov "https://uploader.codecov.io/latest/${CI_OS:-linux}/codecov" ;
-for i in 1 256 512 ; do
-	curl -fLso "codecov.SHA${i}SUM" "https://uploader.codecov.io/latest/${CI_OS:-linux}/codecov.SHA${i}SUM" ; wait ;
-	curl -fLso "codecov.SHA${i}SUM.sig" "https://uploader.codecov.io/latest/${CI_OS:-linux}/codecov.SHA${i}SUM.sig" ; wait ;
-	# test sha1/sha512 signatures if found and sha256 even if not found
-	if [[ ( -r "codecov.SHA${i}SUM" ) ]] || [[ ( ${i} -eq 256 ) ]] ; then
-		if [[ ( -r "codecov.SHA${i}SUM.sig" ) ]] ; then
-			# configure your CI evironment to trust the key at https://keybase.io/codecovsecurity/pgp_keys.asc
-			# FP: 2703 4E7F DB85 0E0B BC2C 62FF 806B B28A ED77 9869
-			# OR...
-			# Set CI=true to continue on missing keys
-			gpgv "codecov.SHA${i}SUM.sig" "codecov.SHA${i}SUM" || ${CI} || EXIT_CODE=126
-			rm -vf "codecov.SHA${i}SUM.sig" 2>/dev/null ;
+if [[ "${CI_OS:-Other}" == "Linux" ]] && [[ ( ${EXIT_CODE} -eq 0 ) ]] && [[ ( ${CI_CODECOV_UPLOAD_ENABLED:-0} -eq 1 ) ]] ; then
+	curl -fLso codecov "https://uploader.codecov.io/latest/${CI_OS:-linux}/codecov" || EXIT_CODE=126 ;
+	for i in 1 256 512 ; do
+		curl -fLso "codecov.SHA${i}SUM" "https://uploader.codecov.io/latest/${CI_OS:-linux}/codecov.SHA${i}SUM" ; wait ;
+		curl -fLso "codecov.SHA${i}SUM.sig" "https://uploader.codecov.io/latest/${CI_OS:-linux}/codecov.SHA${i}SUM.sig" ; wait ;
+		# test sha1/sha512 signatures if found and sha256 even if not found
+		if [[ ( -r "codecov.SHA${i}SUM" ) ]] || [[ ( ${i} -eq 256 ) ]] ; then
+			if [[ ( -r "codecov.SHA${i}SUM.sig" ) ]] ; then
+				# configure your CI evironment to trust the key at https://keybase.io/codecovsecurity/pgp_keys.asc
+				# FP: 2703 4E7F DB85 0E0B BC2C 62FF 806B B28A ED77 9869
+				# OR...
+				# Set CI=true to continue on missing keys
+				gpgv "codecov.SHA${i}SUM.sig" "codecov.SHA${i}SUM" || ${CI} || EXIT_CODE=126
+				rm -vf "codecov.SHA${i}SUM.sig" 2>/dev/null ;
+			fi
+			shasum -a $i -c --ignore-missing "codecov.SHA${i}SUM" || EXIT_CODE=126
+			rm -vf "codecov.SHA${i}SUM" 2>/dev/null ;
 		fi
-		shasum -a $i -c --ignore-missing "codecov.SHA${i}SUM" || EXIT_CODE=126
-		rm -vf "codecov.SHA${i}SUM" 2>/dev/null ;
+	done
+
+	# shellcheck disable=SC2086
+	if [[ ( ${EXIT_CODE} -eq 0 ) ]] ; then
+		chmod 751 ./codecov || EXIT_CODE=126
 	fi
-done
 
-# shellcheck disable=SC2086
-if [[ ( ${EXIT_CODE} -eq 0 ) ]] ; then
-	chmod -v 751 ./codecov || EXIT_CODE=126
-fi
+	# shellcheck disable=SC2086
+	if [[ ( ${EXIT_CODE} -eq 0 ) ]] ; then
+		./codecov --help
+		#./codecov upload-coverage -n "Custom Test Run" -X gcov --flag multicast --git-service github --sha ${VCS_COMMIT_ID} --dir . --file ./test-reports/coverage.xml -Z || EXIT_CODE=10 ;
+	fi
 
-if [[ ( -x $(command -v coverage3) ) ]] ; then
-	coverage3 combine 2>/dev/null || true
-	wait ;
-	coverage3 xml --include=multicast/*,tests/* 2>/dev/null || true
-elif [[ ( -x $(command -v coverage) ) ]] ; then
-	coverage combine 2>/dev/null || true
-	wait ;
-	coverage xml --include=multicast/*,tests/* 2>/dev/null || coverage xml 2>/dev/null || true
-fi
+	rm -f ./codecov 2>/dev/null > /dev/null || true ; wait ;
 
-# shellcheck disable=SC2086
-if [[ ( ${EXIT_CODE} -eq 0 ) ]] ; then
-	./codecov -n "Custom Test Run" -X gcov -F multicast,"${CI_OS:-linux}-latest" -Z || EXIT_CODE=10 ;
-fi
-
+fi ;  # end if linux
 
 unset _TEST_ROOT_DIR 2>/dev/null || true ;
 
-rm -f ./codecov 2>/dev/null > /dev/null || true ; wait ;
 rm -f "${LOCK_FILE}" 2>/dev/null > /dev/null || true ; wait ;
 
 # shellcheck disable=SC2086

--- a/tests/check_spelling
+++ b/tests/check_spelling
@@ -155,6 +155,7 @@ declare -a SPECIFIC_TYPOS=(
 	"rappidly:rapidly"  # from #392
 	"compleated:completed"  # from #338
 	"compleate:complete"  # from #402
+	"excutable:executable"  # from #130
 )
 
 function cleanup() {


### PR DESCRIPTION
# Patch Notes

This patch introduces a new GHA template to upload coverage reports to various services during extended CI/CD testing.

## Impacted GHI

 - [x] Closes #130

## Changes

Additions with file `.github/actions/test-reporter-upload/action.yml`:
 * New GHA action template to handle uploading coverage results to various services

Changes in file `.github/actions/fetch-test-reporter/action.yml`:
 * moved tokens to secrets
 * related work

Changes in file `.github/actions/purge-test-reporter/action.yml`:
 * moved tokens to secrets
 * related work

Changes in file `.github/workflows/Tests.yml`:
 * related work

Changes in file `tests/check_codecov`:
 * refactored a bit to focus on config validation more.

Changes in file `tests/check_spelling`:
 * related work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a consolidated step for uploading code coverage reports to multiple services, streamlining the workflow and improving management of coverage uploads.
  - Added a new GitHub Action to upload code coverage results using multiple coverage reporting tools.

- **Chores**
  - Updated handling of authentication tokens in GitHub Actions to use secrets for improved security.
  - Enhanced OS detection and error handling in coverage upload scripts.
  - Added a new spelling regression test for the word "executable".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->