### PR TITLE
[HOTFIX] fix for updating `checkmake` expected SHA

### DIFF
--- a/.github/workflows/makefile-lint.yml
+++ b/.github/workflows/makefile-lint.yml
@@ -63,10 +63,10 @@ jobs:
         env:
           BUILDER_NAME: "makefile-lint"
           BUILDER_EMAIL: "no-reply@localhost"
+          EXPECTED_SHA: "${{ vars.CHECKMAKE_EXPECTED_SHA }}"
         run: |
           git clone --depth 1 --branch main https://github.com/mrtazz/checkmake.git checkmake
           cd checkmake
-          EXPECTED_SHA="880668e0015d47e9b84ec5edfec4bf67b4228ea4" # v0.2.2+21
           ACTUAL_SHA=$(git rev-parse HEAD)
           if [ "$EXPECTED_SHA" != "$ACTUAL_SHA" ]; then
             ERR_MSG_STUB="Checkmake repository hash verification failed."


### PR DESCRIPTION
# HOTFIX Notes

Introduces the use of a new CI/CD variable: `CHECKMAKE_EXPECTED_SHA` for the expected SHA of the `checkmake` git-repo (_NO ASSOCIATION_)

## Impacted GHI

 - [x] Closes #417

Changes in file .github/workflows/makefile-lint.yml:
 * use new variable configured in GitHub Actions dashboard.
 * related work

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow configuration to use a dynamic environment variable for SHA verification during checkmake installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->